### PR TITLE
[matchbook-types] create single order id type

### DIFF
--- a/packages/matchbook-types/Cargo.lock
+++ b/packages/matchbook-types/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +165,7 @@ name = "matchbook-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "itertools",
  "pretty_assertions",
  "quickcheck",
  "serde",

--- a/packages/matchbook-types/Cargo.toml
+++ b/packages/matchbook-types/Cargo.toml
@@ -14,3 +14,4 @@ quickcheck = "1.0.3"
 serde = {version="1.0.124", features=["derive"]}
 serde_with = "1.6.4"
 chrono = {version = "0.4.19", features=["serde"]}
+itertools = "0.10"

--- a/packages/matchbook-util/Cargo.lock
+++ b/packages/matchbook-util/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fixer-upper"
 version = "0.1.0"
 dependencies = [
@@ -103,6 +109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +143,7 @@ name = "matchbook-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "itertools",
  "serde",
  "serde_with",
 ]

--- a/services/matching-engine/Cargo.lock
+++ b/services/matching-engine/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fixer-upper"
 version = "0.1.0"
 dependencies = [
@@ -222,6 +228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +277,7 @@ name = "matchbook-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "itertools",
  "serde",
  "serde_with",
 ]

--- a/services/matching-engine/src/main.rs
+++ b/services/matching-engine/src/main.rs
@@ -46,8 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         side,
                     } => {
                         info!(
-                            ?message.publisher_id,
-                            ?message.topic_id,
+                            ?message.id,
                             ?side,
                             quantity,
                             ?symbol,

--- a/services/port/Cargo.lock
+++ b/services/port/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fixer-upper"
 version = "0.1.0"
 dependencies = [
@@ -222,6 +228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +277,7 @@ name = "matchbook-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "itertools",
  "serde",
  "serde_with",
 ]


### PR DESCRIPTION
Creates a single type that can be used to uniquely identified for orders. Will be used by the re transmitter in order to uniquely identify a message