### PR TITLE
[matchbook-types] remove sending_time field

### DIFF
--- a/packages/matchbook-types/src/lib.rs
+++ b/packages/matchbook-types/src/lib.rs
@@ -17,7 +17,6 @@ pub type SymbolRef<'a> = &'a SymbolOwned;
 pub struct Message {
     #[serde_as(as = "DisplayFromStr")]
     pub id: MessageId,
-    pub sending_time: UtcTimeStamp,
     pub kind: MessageKind,
 }
 

--- a/services/port/Cargo.lock
+++ b/services/port/Cargo.lock
@@ -12,6 +12,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,11 +307,14 @@ dependencies = [
 name = "matchbook-util"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "fixer-upper",
+ "futures",
  "matchbook-types",
  "serde_json",
  "socket2",
+ "tokio",
  "tokio-util",
 ]
 
@@ -417,6 +441,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "port"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "fixer-upper",
  "futures",
  "itertools",

--- a/services/port/Cargo.lock
+++ b/services/port/Cargo.lock
@@ -12,27 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,14 +286,11 @@ dependencies = [
 name = "matchbook-util"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bytes",
  "fixer-upper",
- "futures",
  "matchbook-types",
  "serde_json",
  "socket2",
- "tokio",
  "tokio-util",
 ]
 

--- a/services/port/Cargo.toml
+++ b/services/port/Cargo.toml
@@ -17,3 +17,4 @@ tokio-util = {version = "0.6.3", features=["net", "codec"]}
 tracing = "0.1"
 tracing-subscriber="0.2"
 itertools = "0.10"
+chrono = "0.4.19"

--- a/services/port/src/message.rs
+++ b/services/port/src/message.rs
@@ -58,7 +58,7 @@ pub fn matchbook_message_into_fix_message(msg: Message) -> FixMessage {
                 sending_time: chrono::Utc::now(),
             },
             body: fixer_upper::Body {
-                cl_ord_id: Some(msg.id.topic_id.to_string()),
+                cl_ord_id: Some(msg.id.topic_id),
                 handl_inst: Some(fixer_upper::HandlInst::ManualOrderBestExecution),
                 symbol: Some(symbol.iter().collect()),
                 side: Some(match side {

--- a/services/port/src/message.rs
+++ b/services/port/src/message.rs
@@ -34,7 +34,6 @@ pub fn fix_message_into_matchbook_message(
                 topic_id: msg.header.sender_comp_id,
                 topic_sequence_n: msg.header.msg_seq_num,
             },
-            sending_time: msg.header.sending_time,
         },
         x => unimplemented!("{:?}", x),
     })
@@ -56,7 +55,7 @@ pub fn matchbook_message_into_fix_message(msg: Message) -> FixMessage {
                 sender_comp_id: String::from("matchbook"),
                 target_comp_id: msg.id.topic_id.to_string(),
                 msg_seq_num: msg.id.topic_sequence_n,
-                sending_time: msg.sending_time,
+                sending_time: chrono::Utc::now(),
             },
             body: fixer_upper::Body {
                 cl_ord_id: Some(msg.id.topic_id.to_string()),
@@ -66,7 +65,7 @@ pub fn matchbook_message_into_fix_message(msg: Message) -> FixMessage {
                     Side::Ask => fixer_upper::Side::Sell,
                     Side::Bid => fixer_upper::Side::Buy,
                 }),
-                transact_time: Some(msg.sending_time),
+                transact_time: Some(chrono::Utc::now()),
                 ord_type: Some(fixer_upper::OrderType::Limit),
                 order_qty: Some(quantity as fixer_upper::Price),
                 price: Some(price as fixer_upper::Price),
@@ -90,7 +89,7 @@ pub fn matchbook_message_into_fix_message(msg: Message) -> FixMessage {
                 sender_comp_id: String::from("matchbook"),
                 target_comp_id: msg.id.topic_id.to_string(),
                 msg_seq_num: msg.id.topic_sequence_n,
-                sending_time: msg.sending_time,
+                sending_time: chrono::Utc::now(),
             },
             body: fixer_upper::Body {
                 order_id: Some("foobar".to_string()), // TODO(will): where does this come from

--- a/services/retransmitter/src/main.rs
+++ b/services/retransmitter/src/main.rs
@@ -100,7 +100,6 @@ mod test {
 
         let first_received = Message {
             id: id.clone(),
-            sending_time: chrono::Utc::now(),
             kind: MessageKind::LimitOrderSubmitRequest {
                 side: Side::Bid,
                 price: 100,
@@ -111,7 +110,6 @@ mod test {
 
         let id_colliding_message = Message {
             id: id.clone(),
-            sending_time: chrono::Utc::now(),
             kind: MessageKind::LimitOrderSubmitRequest {
                 side: Side::Bid,
                 price: 100,
@@ -123,7 +121,6 @@ mod test {
         let retransmit_req = Message {
             id: id.clone(),
             kind: MessageKind::RetransmitRequest,
-            sending_time: chrono::Utc::now(),
         };
 
         stream_tx
@@ -186,7 +183,6 @@ mod test {
                         topic_id: String::from("foobar"),
                         topic_sequence_n: 1000,
                     },
-                    sending_time: chrono::Utc::now(),
                     kind: MessageKind::RetransmitRequest,
                 },
                 multicast_addr,
@@ -210,7 +206,6 @@ mod test {
 
         let to_retransmit_1 = Message {
             id: to_retransmit_id_1.clone(),
-            sending_time: chrono::Utc::now(),
             kind: MessageKind::LimitOrderSubmitRequest {
                 side: Side::Bid,
                 price: 100,
@@ -230,7 +225,6 @@ mod test {
 
         let to_retransmit_2 = Message {
             id: to_retransmit_id_2.clone(),
-            sending_time: chrono::Utc::now(),
             kind: MessageKind::LimitOrderSubmitRequest {
                 side: Side::Bid,
                 price: 100,
@@ -242,13 +236,11 @@ mod test {
         let retransmit_1_req = Message {
             id: to_retransmit_id_1.clone(),
             kind: MessageKind::RetransmitRequest,
-            sending_time: chrono::Utc::now(),
         };
 
         let retransmit_2_req = Message {
             id: to_retransmit_id_2.clone(),
             kind: MessageKind::RetransmitRequest,
-            sending_time: chrono::Utc::now(),
         };
 
         let (sink_tx, mut sink_rx) = futures::channel::mpsc::channel(1);


### PR DESCRIPTION
Messages on the matchbook internal network don't need to care about time. Only the port service's interface between the client and server have any concept of time because of the [SendingTime](https://www.onixs.biz/fix-dictionary/4.2/tagnum_52.html) and [TransactTime](https://www.onixs.biz/fix-dictionary/4.2/tagnum_60.html) fields. 